### PR TITLE
Update to Solr 9.0.0

### DIFF
--- a/Voikko/pom.xml
+++ b/Voikko/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>fi.nationallibrary.ndl</groupId>
   <artifactId>solrvoikko2</artifactId>
-  <version>2.6.0-SOLR-8.8.1-SNAPSHOT</version>
+  <version>2.6.0-SOLR-9.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>solrvoikko</name>
@@ -29,7 +29,7 @@
     <dependency>
     	<groupId>org.apache.solr</groupId>
     	<artifactId>solr-core</artifactId>
-    	<version>8.8.1</version>
+    	<version>9.0.0</version>
     </dependency>
     <dependency>
     	<groupId>javax.servlet</groupId>

--- a/Voikko/src/main/java/fi/nationallibrary/ndl/solrvoikko2/VoikkoFilterFactory.java
+++ b/Voikko/src/main/java/fi/nationallibrary/ndl/solrvoikko2/VoikkoFilterFactory.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.puimula.libvoikko.Voikko;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;


### PR DESCRIPTION
side note:

Solr 9.0.0 ships with Security Manager enabled by default, which causes Voikko to not work.
To get it to work you need to modify Security Manager policy or launch Solr with
SOLR_SECURITY_MANAGER_ENABLED=false